### PR TITLE
Added link to Chisel

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -29,6 +29,7 @@
         <li><a href="https://bitbucket.com">Bitbucket</a> – git, mercurial</li>
         <li><a href="https://launchpad.net/">Launchpad</a> – bazaar, git</li>
         <li><a href="http://savannah.gnu.org/">Savannah</a> – bazaar, svn, mercurial, git</li>
+        <li><a href="http://chiselapp.com/">Chisel</a> – fossil, possible to self-host</li>
       </ul>
 
       <h2>Mirror operators,</h2>


### PR DESCRIPTION
Chisel allows you to host Fossil repositories for free. Fossil repositories come with a built-in issue tracker and wiki, so you don't get locked in. It can import from CVS and Git.
