### PR TITLE
Add Framasoft's GitLab

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -32,6 +32,7 @@
         <li><a href="https://savannah.gnu.org/">Savannah</a> – bazaar, svn, mercurial, git</li>
         <li><a href="https://git.directory/">Git.Directory</a> - git, based on GitLab</li>
 	<li><a href="http://chiselapp.com/">Chisel</a> – fossil, possible to self-host</li>
+	<li><a href="https://git.framasoft.org/">Framasoft GitLab</a> – git</li>
       </ul>
 
       <h2>Mirror operators,</h2>


### PR DESCRIPTION
Framasoft is a french non-profit organisation who aims to promote free software and free culture for more than 10 years. (see https://fr.wikipedia.org/wiki/Framasoft )
We launch 6 months ago a project called http://degooglisons-internet.org ("ungooglize internet") who aim to inform on the risks of web&data centralization, and make the demonstration than free software is (the only ?) answer to this kind of issue.

We opened in march 2015 our own gitlab repository to anybody ( http://framablog.org/2015/03/13/google-code-ferme-ses-portes-nous-on-les-ouvre/ ) and we're hosting around 1 000 projects since then.
