### PR TITLE
Github and Launchpad both offer binary downloads

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -67,7 +67,7 @@
         <td class="feature yes">yes</td><!-- wiki -->
         <td class="feature yes">yes</td><!-- webhosting -->
         <td class="feature no">no</td><!-- mailing list -->
-        <td class="feature"></td><!-- binary downloads -->
+        <td class="feature yes">yes</td><!-- binary downloads -->
         <td class="feature yes">yes</td><!-- free public -->
         <td class="feature no">no</td><!-- free private -->
         <td class="feature no">no</td><!-- selfhost-->
@@ -139,7 +139,7 @@
         <td class="feature no">no</td><!-- wiki -->
         <td class="feature no">no</td><!-- webhosting -->
         <td class="feature yes">yes</td><!-- mailing list -->
-        <td class="feature"></td><!-- binary downloads -->
+        <td class="feature yes">yes</td><!-- binary downloads -->
         <td class="feature yes">yes</td><!-- free public -->
         <td class="feature part" title="only for security updates, according to Wikipedia">yes</td><!-- free private -->
         <td class="feature yes">yes</td><!-- selfhost-->


### PR DESCRIPTION
Both sites allow binary downloads. In Github you can attach "binaries" when you go to create a "Release". In launchpad you can add binaries to a Downloads section and it drives Ubuntu's PPA system for apt-getting
