### PR TITLE
Savannah only hosts projects with GPL compatible licenses

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -257,7 +257,7 @@
         <td class="feature yes">yes</td><!-- webhosting -->
         <td class="feature yes">yes</td><!-- mailing list -->
         <td class="feature"></td><!-- binary downloads -->
-        <td class="feature yes">yes</td><!-- free public -->
+        <td class="feature part" title="GPL compatible projects only">yes</td><!-- free public -->
         <td class="feature no">no</td><!-- free private -->
         <td class="feature yes">yes</td><!-- selfhost-->
       </tr>


### PR DESCRIPTION
Savannah only hosts new projects with GPL compatible licenses
Your project must be approved AND they require the projects to be GPL compatible.
No MIT or BSD or other projects. (Only legacy projects are like that it seems)
So the hosting is not entirely free
