### PR TITLE
Updating Savannah

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -275,10 +275,10 @@
         <td class="vcs no">no</td><!-- fossil -->
         
         <td class="feature yes">yes</td><!-- issues -->
-        <td class="feature no">no</td><!-- wiki -->
+        <td class="feature yes">yes</td><!-- wiki -->
         <td class="feature yes">yes</td><!-- webhosting -->
         <td class="feature yes">yes</td><!-- mailing list -->
-        <td class="feature"></td><!-- binary downloads -->
+        <td class="feature yes">yes</td><!-- binary downloads -->
         <td class="feature part" title="GPL compatible projects only">yes</td><!-- free public -->
         <td class="feature no">no</td><!-- free private -->
         <td class="feature yes">yes</td><!-- selfhost-->


### PR DESCRIPTION
Savannah has downloads (via ftp.nongnu.org, widely mirrored) for projects and wiki functionality (called Cookbook docs)
