### PR TITLE
Add CVS support

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -53,6 +53,7 @@
         <th class="vcs"><span>git&nbsp;&nbsp;&nbsp;&nbsp;</span></th>
         <th class="vcs"><span>mercurial</span></th>
         <th class="vcs"><span>subversion</span></th>
+        <th class="vcs"><span>cvs</span></th>
         <th class="vcs"><span>bazaar</span></th>
         <th class="vcs"><span>fossil</span></th>
         
@@ -73,6 +74,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs yes">yes</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -91,6 +93,7 @@
         <td class="vcs no">no</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs yes">yes</td><!-- fossil -->
         
@@ -109,6 +112,7 @@
         <td class="vcs no">no</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -145,6 +149,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs yes">yes</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -163,6 +168,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -181,6 +187,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -199,6 +206,7 @@
         <td class="vcs no">no</td><!-- git -->
         <td class="vcs yes">yes</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
 
@@ -217,6 +225,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs yes">yes</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -235,6 +244,7 @@
         <td class="vcs part" title="alpha quality; unfinished support">yes</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs yes">yes</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -253,6 +263,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs yes">yes</td><!-- mercurial -->
         <td class="vcs yes">yes</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -271,6 +282,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs yes">yes</td><!-- mercurial -->
         <td class="vcs yes">yes</td><!-- svn -->
+        <td class="vcs no">yes</td><!-- cvs -->
         <td class="vcs yes">yes</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         
@@ -289,6 +301,7 @@
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
         <td class="vcs yes">yes</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         

--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -130,7 +130,8 @@
         
         <td class="vcs yes">yes</td><!-- git -->
         <td class="vcs no">no</td><!-- mercurial -->
-        <td class="vcs no">yes</td><!-- svn -->
+        <td class="vcs no">no</td><!-- svn -->
+        <td class="vcs no">no</td><!-- cvs -->
         <td class="vcs no">no</td><!-- bazaar -->
         <td class="vcs no">no</td><!-- fossil -->
         


### PR DESCRIPTION
Quite a few projects are still using CVS, including many GNU projects, OpenBSD, etc. SourceForge supports CVS.
