### PR TITLE
Update bitbucket self-hosting

### DIFF
--- a/goodbye-sourceforge/index.html
+++ b/goodbye-sourceforge/index.html
@@ -85,7 +85,7 @@
         <td class="feature yes">yes</td><!-- binary downloads -->
         <td class="feature yes">yes</td><!-- free public -->
         <td class="feature part" title="up to 5 users">yes</td><!-- free private -->
-        <td class="feature no">no</td><!-- selfhost-->
+        <td class="feature yes">yes</td><!-- selfhost-->
       </tr>
       <tr>
         <td class="name"><a href="http://chiselapp.com/">Chisel</a></td>


### PR DESCRIPTION
Atlassian offers licenses to self-host bitbucket. They also provide the source code for customization. It is free for open-source, nonprofits, and edu.
